### PR TITLE
Allow all existing roles in OpenAPI and remove redundant ones

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,14 @@
         "no-var": "error",
         "prefer-const": "error",
         "max-len": ["warn", { "code": 120 }],
-        "no-unused-vars": "warn",
+        "no-unused-vars": [
+            "warn",
+            {
+                "varsIgnorePattern": "^_",
+                "argsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }
+        ],
         "no-console": "warn",
         "no-undef": "warn",
         "comma-dangle": ["error", "never"]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -43,6 +43,7 @@ components:
         - ADMIN
         - USER1
         - USER2
+        - INACTIVE
       example: USER
     Product:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -42,6 +42,7 @@ components:
       enum:
         - ADMIN
         - USER1
+        - USER2
       example: USER
     Product:
       type: object

--- a/src/db/migrations/20240306092430_redundant_roles.js
+++ b/src/db/migrations/20240306092430_redundant_roles.js
@@ -1,0 +1,7 @@
+exports.up = async (knex) => {
+    await knex('ROLE').whereIn('role', ['USER3', 'USER4', 'MULKKU']).delete();
+};
+
+exports.down = async (_knex) => {
+    // No need to revert this as in theory it's uknown which of these roles existed
+};

--- a/src/db/seeds/seeddata/ROLE.json
+++ b/src/db/seeds/seeddata/ROLE.json
@@ -21,27 +21,6 @@
         "bgcolor": 47
     },
     {
-        "roleid": 4,
-        "role": "USER3",
-        "buzzerlimit": -5000,
-        "fgcolor": 32,
-        "bgcolor": 40
-    },
-    {
-        "roleid": 5,
-        "role": "USER4",
-        "buzzerlimit": -1000,
-        "fgcolor": 37,
-        "bgcolor": 40
-    },
-    {
-        "roleid": 6,
-        "role": "MULKKU",
-        "buzzerlimit": -1000,
-        "fgcolor": 37,
-        "bgcolor": 40
-    },
-    {
         "roleid": 7,
         "role": "INACTIVE",
         "buzzerlimit": -1000,

--- a/src/db/seeds/seeddata/RVPERSON.js
+++ b/src/db/seeds/seeddata/RVPERSON.js
@@ -32,5 +32,15 @@ module.exports = [
         pass: bcrypt.hashSync('role2', 11),
         saldo: -500,
         realname: 'User Two'
+    },
+    {
+        userid: 4,
+        createdate: new Date('2022-02-20T00:00:00Z'),
+        roleid: 7,
+        name: 'user_inactive',
+        univident: 'inactive@example.com',
+        pass: bcrypt.hashSync('inactive', 11),
+        saldo: -1100,
+        realname: 'Inactive User'
     }
 ];

--- a/src/db/seeds/seeddata/RVPERSON.js
+++ b/src/db/seeds/seeddata/RVPERSON.js
@@ -22,5 +22,15 @@ module.exports = [
         saldo: 500,
         realname: 'BOFH',
         rfid: bcrypt.hashSync('1234', user_store.RFID_SALT)
+    },
+    {
+        userid: 3,
+        createdate: new Date('2024-02-20T00:00:00Z'),
+        roleid: 3,
+        name: 'user_2',
+        univident: 'user2@example.com',
+        pass: bcrypt.hashSync('role2', 11),
+        saldo: -500,
+        realname: 'User Two'
     }
 ];


### PR DESCRIPTION
The backend code was build to handle all existing user roles but this was not reflected in OpenAPI spec.
There are more roles listed in ROLE.json but these will not be handled for now as there are either no user with these role or are just test users that will not be needed/created in the future.

In production all existing users with any role are returned reagardless of the spec so they should still be handled correctly in the frontends. Created an additional test user to allow testing this in the frontend.