### PR TITLE
Set RVITEM and PRODGROUP sequence correctly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,13 @@
     "rules": {
         "indent": ["error", 4, { "SwitchCase": 1 }],
         "linebreak-style": ["error", "unix"],
-        "quotes": ["error", "single"],
+        "quotes": [
+            "error",
+            "single",
+            {
+                "avoidEscape": true
+            }
+        ],
         "semi": ["error", "always"],
         "arrow-parens": ["error", "always"],
         "no-trailing-spaces": "error",

--- a/src/db/seeds/development/003_prodgroup_and_items.js
+++ b/src/db/seeds/development/003_prodgroup_and_items.js
@@ -5,15 +5,15 @@ exports.seed = async (knex) => {
     await knex('PRODGROUP').insert(prodgroups);
     await knex.raw(`
         select setval(
-            pg_get_serial_sequence('"PRODGROUP"', 'pgrpid'),
+            pg_get_serial_sequence('"PRODGROUP_ALL"', 'pgrpid'),
             coalesce(max(pgrpid), 0)
-        ) from "PRODGROUP"
+        ) from "PRODGROUP_ALL"
     `);
     await knex('RVITEM').insert(rvitems);
     await knex.raw(`
         select setval(
-            pg_get_serial_sequence('"RVITEM"', 'itemid'),
+            pg_get_serial_sequence('"RVITEM_ALL"', 'itemid'),
             coalesce(max(itemid), 0)
-        ) from "RVITEM"
+        ) from "RVITEM_ALL"
     `);
 };


### PR DESCRIPTION
RVITEM and PRODGROUP tables were renamed to RVITEM_ALL and PRODGROUP_ALL causing the seed files to set the RVITEM sequence incorrectly to 1 making product creation fail on duplicate id as they were still using the RVITEM view. PRODGROUP seed had the same problem. 